### PR TITLE
[WIP] Add 'add' route to vmexpire

### DIFF
--- a/etc/os-vm-expire/policy.json
+++ b/etc/os-vm-expire/policy.json
@@ -3,6 +3,7 @@
     "admin_or_owner":  "is_admin:True or project_id:%(project_id)s",
     "default": "rule:admin_or_owner",
     "vmexpire:get": "rule:admin_or_owner",
+    "vmexpire:add": "rule:context_is_admin",
     "vmexpire:extend": "rule:admin_or_owner",
     "vmexpire:delete": "rule:context_is_admin"
 }

--- a/etc/oslo-config-generator/policy.json.sample
+++ b/etc/oslo-config-generator/policy.json.sample
@@ -3,6 +3,7 @@
     "admin_or_owner":  "rule:context_is_admin or is_admin:True or project_id:%(project_id)s",
     "default": "rule:admin_or_owner",
     "vmexpire:get": "rule:admin_or_owner",
+    "vmexpire:add": "rule:context_is_admin",
     "vmexpire:extend": "rule:admin_or_owner",
     "vmexpire:delete": "rule:context_is_admin",
     "vmexclude:get": "rule:admin",

--- a/os_vm_expire/api/controllers/vmexpire.py
+++ b/os_vm_expire/api/controllers/vmexpire.py
@@ -91,6 +91,24 @@ class VmExpireController(controllers.ACLMixin):
         repo.commit()
         return instances_resp_overall
 
+    @index.when(method='POST', template='json')
+    @controllers.handle_exceptions(u._('VmExpire add'))
+    @controllers.enforce_rbac('vmexpire:add')
+    @controllers.enforce_content_types(['application/json'])
+    def on_post(self, meta, instance_id):
+        instance = None
+        try:
+            instance = self.vmexpire_repo.add_vm(entity_id=instance_id)
+        except Exception as e:
+            pecan.response.status = 403
+            return str(e)
+        # url = hrefs.convert_vmexpire_to_href(instance.id)
+        repo.commit()
+        pecan.response.status = 202
+        return {
+            'vmexpire': hrefs.convert_to_hrefs(instance.to_dict_fields())
+        }
+
     @index.when(method='PUT', template='json')
     @controllers.handle_exceptions(u._('VmExpire extend'))
     @controllers.enforce_rbac('vmexpire:extend')

--- a/os_vm_expire/common/policies/acls.py
+++ b/os_vm_expire/common/policies/acls.py
@@ -16,6 +16,8 @@ from oslo_policy import policy
 rules = [
     policy.RuleDefault('vmexpire:get',
                        'rule:admin_or_user'),
+    policy.RuleDefault('vmexpire:add',
+                       'rule:admin'),
     policy.RuleDefault('vmexpire:extend',
                        'rule:admin_or_user'),
     policy.RuleDefault('vmexpire:delete',

--- a/os_vm_expire/common/policies/base.py
+++ b/os_vm_expire/common/policies/base.py
@@ -28,6 +28,7 @@ rules = [
     "admin_or_owner": "rule:context_is_admin or is_admin:True or project_id:%(project_id)s",
     "default": "rule:admin_or_owner",
     "vmexpire:get": "rule:admin_or_owner",
+    "vmexpire:add": "rule:admin",
     "vmexpire:extend": "rule:admin_or_owner",
     "vmexpire:delete": "rule:context_is_admin",
     "vmexclude:get": "rule:admin",

--- a/os_vm_expire/model/migration/alembic_migrations/versions/3cf9516e9a67_create_exclude_table.py
+++ b/os_vm_expire/model/migration/alembic_migrations/versions/3cf9516e9a67_create_exclude_table.py
@@ -31,7 +31,7 @@ down_revision = 'newton'
 def upgrade():
     ctx = op.get_context()
     con = op.get_bind()
-    table_exists = ctx.dialect.has_table(con.engine, 'vmexclude')
+    table_exists = ctx.dialect.has_table(con, 'vmexclude')
     if not table_exists:
         op.create_table(
             'vmexclude',

--- a/os_vm_expire/model/repositories.py
+++ b/os_vm_expire/model/repositories.py
@@ -40,7 +40,8 @@ from os_vm_expire.common import utils
 from os_vm_expire import i18n as u
 from os_vm_expire.model.migration import commands
 from os_vm_expire.model import models
-from os_vm_expire.queue import get_instance, get_project_domain
+from os_vm_expire.queue.server import get_instance
+from os_vm_expire.queue.server import get_project_domain
 
 LOG = utils.getLogger(__name__)
 

--- a/os_vm_expire/model/repositories.py
+++ b/os_vm_expire/model/repositories.py
@@ -309,10 +309,9 @@ class BaseRepo(object):
     def add_vm(self, instance_uuid, session=None):
         session = self.get_session(session)
 
-        repo = get_vmexpire_repository()
         instance = None
         try:
-            instance = repo.get_by_instance(instance_uuid)
+            instance = self.get_by_instance(instance_uuid)
         except Exception:
             LOG.debug("Fine, instance does not already exists")
         if instance:
@@ -320,7 +319,7 @@ class BaseRepo(object):
                      instance_uuid +
                      ", deleting first"
                      )
-            repo.delete_entity_by_id(entity_id=instance.id)
+            self.delete_entity_by_id(entity_id=instance.id)
 
         instance_data = get_instance(instance_uuid)
         if not instance_data:
@@ -362,7 +361,7 @@ class BaseRepo(object):
             LOG.debug('user %s is excluded, skipping' % (entity.user_id))
             return
 
-        instance = repo.create_from(entity)
+        instance = self.create_from(entity, session)
         LOG.debug("NewInstanceExpiration:" + instance_uuid)
         return instance
 

--- a/os_vm_expire/tests/api/test_resources_policy.py
+++ b/os_vm_expire/tests/api/test_resources_policy.py
@@ -97,7 +97,7 @@ class BaseTestCase(utils.OsVMExpireAPIBaseTestCase, utils.MockModelRepositoryMix
             'user': user_id,
             'project': project_id,
             'roles': roles or [],
-            'policy_enforcer': self.policy_enforcer,
+            'policy_enforcer': self.policy_enforcer
         }
         req.environ = {}
         req.environ['os_vm_expire.context'] = context.RequestContext(**kwargs)
@@ -278,6 +278,20 @@ class WhenTestingVmExpireResource(BaseTestCase):
             project_id=self.project_id)
         self.assertRaises(webob.exc.HTTPForbidden, self._invoke_on_delete, '12345')
 
+    def test_should_pass_add_vmexpire(self):
+        self.req = self._generate_req(roles=['admin'],
+            content_type='application/json')
+        res = self._invoke_on_post('12345expire')
+        self.assertIsNotNone(res)
+
+    def test_should_fail_add_vmexpires(self):
+        self.req = self._generate_req(roles=['bogus'])
+        self.assertRaises(webob.exc.HTTPForbidden, self._invoke_on_post, '12345')
+
+    def test_should_fail_user_add_vmexpire(self):
+        self.req = self._generate_req(roles=['member'])
+        self.assertRaises(webob.exc.HTTPForbidden, self._invoke_on_post, '12345')
+
     def _invoke_on_put(self, instance_id=None):
         return self.resource.on_put(self.req, self.resp, 'vmexpires', instance_id)
 
@@ -286,3 +300,6 @@ class WhenTestingVmExpireResource(BaseTestCase):
 
     def _invoke_on_get(self, instance_id=None):
         return self.resource.on_get(self.req, self.resp, 'vmexpires', instance_id)
+
+    def _invoke_on_post(self, instance_id=None):
+        return self.resource.on_post(self.req, self.resp, 'vmexpires', instance_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ WebOb
 keystonemiddleware
 pecan!=1.0.2,!=1.0.3,!=1.0.4,!=1.2,>=1.0.0
 six>=1.9.0 # MIT
-SQLAlchemy!=1.1.5,!=1.1.6,!=1.1.7,!=1.1.8,>=1.0.10 # MIT
+SQLAlchemy!=1.1.5,!=1.1.6,!=1.1.7,!=1.1.8,>=1.4.8 # MIT
 alembic>=0.8.10 # MIT
 prettytable


### PR DESCRIPTION
Since vmexpire only manage instances created after its installation, we need a way to manually add openstack instances to it.
This PR add an admin-restricted POST route /vmexpire/instance_id  which should add an existing openstack instance to the DB.

TODO:

- Add cli
- Tests? Basics ACL tests are done, but since it require an existing openstack instance, not sure how to test it.